### PR TITLE
Add image caching extension for UIImageView

### DIFF
--- a/Interview.xcodeproj/project.pbxproj
+++ b/Interview.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		6AB24DF823EB558D00530BA5 /* ContactCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AB24DF723EB558D00530BA5 /* ContactCell.swift */; };
 		6ABE2F9024CEF691009D7593 /* ListContactServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ABE2F8F24CEF691009D7593 /* ListContactServiceTests.swift */; };
 		B163815028775CAD0096BF33 /* ListContactViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B163814F28775CAD0096BF33 /* ListContactViewModelTests.swift */; };
+		F058DFE12E1D5723008845B9 /* UIImageView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F058DFE02E1D570D008845B9 /* UIImageView+Extension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -46,6 +47,7 @@
 		6AB24DF723EB558D00530BA5 /* ContactCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactCell.swift; sourceTree = "<group>"; };
 		6ABE2F8F24CEF691009D7593 /* ListContactServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListContactServiceTests.swift; sourceTree = "<group>"; };
 		B163814F28775CAD0096BF33 /* ListContactViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListContactViewModelTests.swift; sourceTree = "<group>"; };
+		F058DFE02E1D570D008845B9 /* UIImageView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+Extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -87,6 +89,7 @@
 		6AB24DBE23EB546D00530BA5 /* Interview */ = {
 			isa = PBXGroup;
 			children = (
+				F058DFE22E1D5727008845B9 /* Extensions */,
 				6AB24DF923EB55D400530BA5 /* Resources */,
 				6AB24DEB23EB54F500530BA5 /* Scenes */,
 				6AB24DBF23EB546D00530BA5 /* AppDelegate.swift */,
@@ -199,6 +202,14 @@
 			path = Service;
 			sourceTree = "<group>";
 		};
+		F058DFE22E1D5727008845B9 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				F058DFE02E1D570D008845B9 /* UIImageView+Extension.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -301,6 +312,7 @@
 			files = (
 				6AB24DEF23EB552100530BA5 /* Contact.swift in Sources */,
 				6AB24DEA23EB54E800530BA5 /* ListContactsViewController.swift in Sources */,
+				F058DFE12E1D5723008845B9 /* UIImageView+Extension.swift in Sources */,
 				6AB24DF523EB556700530BA5 /* ListContactsService.swift in Sources */,
 				6AB24DC023EB546D00530BA5 /* AppDelegate.swift in Sources */,
 				6AB24DF223EB554300530BA5 /* ListContactsViewModel.swift in Sources */,

--- a/Interview/Extensions/UIImageView+Extension.swift
+++ b/Interview/Extensions/UIImageView+Extension.swift
@@ -1,0 +1,37 @@
+//
+//  UIImageView+Extension.swift
+//  Interview
+//
+//  Created by Neylor Bagagi on 08/07/25.
+//  Copyright © 2025 PicPay. All rights reserved.
+//
+
+import UIKit
+
+let cache = NSCache<NSString, UIImage>()
+
+extension UIImageView {
+    
+    func setImage(from stringURL: String) {
+        
+        guard let url = URL(string: stringURL) else { return }
+        
+        if let imageCache = cache.object(forKey: url.absoluteString as NSString) {
+            self.image = imageCache
+            return
+        }
+            
+        URLSession.shared.dataTask(with: url) { data, response, error in
+            guard let data = data,
+                  let image = UIImage(data: data),
+                  error == nil else {
+                return
+            }
+            
+            DispatchQueue.main.async {
+                cache.setObject(image, forKey: url.absoluteString as NSString)
+                self.image = image
+            }
+        }.resume()
+    }
+}

--- a/Interview/Scenes/ListContacts/Models/Contact.swift
+++ b/Interview/Scenes/ListContacts/Models/Contact.swift
@@ -11,6 +11,7 @@ import Foundation
 ]
 */
 
+// TODO: Esse model pode ser um struct
 class Contact: Codable {
     var id: Int
     var name: String = ""

--- a/Interview/Scenes/ListContacts/Services/ListContactsService.swift
+++ b/Interview/Scenes/ListContacts/Services/ListContactsService.swift
@@ -5,12 +5,14 @@ private let apiURL = "https://669ff1b9b132e2c136ffa741.mockapi.io/picpay/ios/int
 class ListContactService {
     func fetchContacts(completion: @escaping ([Contact]?, Error?) -> Void) {
         guard let api = URL(string: apiURL) else {
+            // TODO: Adicionar retorno de error de URL inválida
             return
         }
         
         let session = URLSession.shared
         let task = session.dataTask(with: api) { (data, response, error) in
             guard let jsonData = data else {
+                // TODO: Adicionar retorno de código response
                 return
             }
             

--- a/Interview/Scenes/ListContacts/Views/ContactCell.swift
+++ b/Interview/Scenes/ListContacts/Views/ContactCell.swift
@@ -22,6 +22,10 @@ class ContactCell: UITableViewCell {
         configureViews()
     }
     
+    override func prepareForReuse() {
+            contactImage.image = nil
+        }
+    
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         

--- a/Interview/Scenes/ListContacts/Views/ListContactsViewController.swift
+++ b/Interview/Scenes/ListContacts/Views/ListContactsViewController.swift
@@ -82,14 +82,7 @@ class ListContactsViewController: UIViewController, UITableViewDataSource, UITab
         
         let contact = contacts[indexPath.row]
         cell.fullnameLabel.text = contact.name
-        
-        if let urlPhoto = URL(string: contact.photoURL) {
-            do {
-                let data = try Data(contentsOf: urlPhoto)
-                let image = UIImage(data: data)
-                cell.contactImage.image = image
-            } catch _ {}
-        }
+        cell.contactImage.setImage(from: contact.photoURL)
         
         return cell
     }


### PR DESCRIPTION
Introduced UIImageView+Extension.swift to asynchronously load and cache images from URLs, improving performance and responsiveness in contact list cells. Updated ListContactsViewController to use the new extension and refactored ContactCell to clear images on reuse. Added TODOs for error handling in ListContactsService and a note to consider making Contact a struct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability for contact images to load asynchronously from a URL, with caching for improved performance.

* **Bug Fixes**
  * Ensured contact images are reset when cells are reused, preventing incorrect images from appearing during fast scrolling.

* **Refactor**
  * Simplified image loading in the contact list to use the new asynchronous method. 

* **Documentation**
  * Added comments and TODOs for future improvements in data models and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->