### PR TITLE
Set placeholder image in setImage extension

### DIFF
--- a/Interview/Extensions/UIImageView+Extension.swift
+++ b/Interview/Extensions/UIImageView+Extension.swift
@@ -13,6 +13,7 @@ let cache = NSCache<NSString, UIImage>()
 extension UIImageView {
     
     func setImage(from stringURL: String) {
+        image = UIImage(systemName: "photo")
         
         guard let url = URL(string: stringURL) else { return }
         


### PR DESCRIPTION
Added a default system 'photo' placeholder image to UIImageView before loading the image from a URL in the setImage(from:) extension.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image views now display a default placeholder image immediately while loading images from a URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->