### PR TITLE
Add protocol-based networking and unit tests for ListContactService

### DIFF
--- a/Interview/Scenes/ListContacts/Views/ListContactsViewController.swift
+++ b/Interview/Scenes/ListContacts/Views/ListContactsViewController.swift
@@ -73,7 +73,7 @@ class ListContactsViewController: UIViewController {
         ])
     }
     
-    func binding() {
+    private func binding() {
         viewModel.contactsSubject
             .receive(on: DispatchQueue.main)
             .sink { completion in

--- a/InterviewTests/Scenes/ListContacts/Service/ListContactServiceTests.swift
+++ b/InterviewTests/Scenes/ListContacts/Service/ListContactServiceTests.swift
@@ -2,13 +2,55 @@ import XCTest
 @testable import Interview
 
 class ListContactServiceTests: XCTestCase {
+    var service: ListContactService!
+    var mockSession: MockURLSession!
 
     override func setUp() {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+        super.setUp()
+        mockSession = MockURLSession()
+        service = ListContactService(session: mockSession)
     }
 
     override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        service = nil
+        mockSession = nil
+        super.tearDown()
+    }
+
+    func testFetchContacts_Success() {
+        mockSession.data = mockData
+        let expectation = self.expectation(description: "Contacts fetched")
+        service.fetchContacts { contacts, error in
+            XCTAssertNotNil(contacts)
+            XCTAssertNil(error)
+            XCTAssertEqual(contacts?.count, 1)
+            XCTAssertEqual(contacts?.first?.name, "Beyonce")
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    func testFetchContacts_DecodingError() {
+        mockSession.data = "invalid json".data(using: .utf8)
+        let expectation = self.expectation(description: "Decoding error")
+        service.fetchContacts { contacts, error in
+            XCTAssertNil(contacts)
+            XCTAssertNotNil(error)
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    func testFetchContacts_NetworkError() {
+        mockSession.data = nil
+        mockSession.error = NSError(domain: "Test", code: 1, userInfo: nil)
+        let expectation = self.expectation(description: "Network error")
+        service.fetchContacts { contacts, error in
+            XCTAssertNil(contacts)
+            XCTAssertNotNil(error)
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
     }
 }
 


### PR DESCRIPTION
Refactored ListContactService to use protocol-based dependency injection for URLSession, enabling easier mocking and testing. Added protocols and mock classes for URLSession and URLSessionDataTask. Updated ListContactsViewController to make binding method private. Introduced comprehensive unit tests for ListContactService covering success, decoding error, and network error scenarios.