### PR TITLE
Refactor ListContacts to use event stream for effects

### DIFF
--- a/Interview/Features/ListContacts/Sources/Core/ListContactsEffectsManager.swift
+++ b/Interview/Features/ListContacts/Sources/Core/ListContactsEffectsManager.swift
@@ -1,0 +1,40 @@
+//
+//  ListContactsEffectsManager.swift
+//  Interview
+//
+//  Created by Neylor Bagagi on 14/07/25.
+//
+
+import Combine
+
+protocol ListContactsEffectsCreating {
+    func viewDidLoad()
+}
+
+final class ListContactsEffectsManager: ListContactsEffectsCreating {
+        
+    private var eventStreamOutlet: ListContactsEventStream.Outlet
+    private let dataProvider: ListContactsDataProviding
+    private var cancellables = Set<AnyCancellable>()
+    
+    init(eventStreamOutlet: ListContactsEventStream.Outlet,
+         dataProvider: ListContactsDataProviding) {
+        self.eventStreamOutlet = eventStreamOutlet
+        self.dataProvider = dataProvider
+        
+        binding()
+    }
+    
+    private func binding() {
+        eventStreamOutlet.sink { [weak self] event in
+            switch event {
+                case .viewDidLoad:
+                    self?.viewDidLoad()
+            }
+        }.store(in: &cancellables)
+    }
+    
+    internal func viewDidLoad() {
+        self.dataProvider.getListContactsData()
+    }
+}

--- a/Interview/Features/ListContacts/Sources/Core/ListContactsEvent.swift
+++ b/Interview/Features/ListContacts/Sources/Core/ListContactsEvent.swift
@@ -1,0 +1,16 @@
+//
+//  ListContactsEvent.swift
+//  Interview
+//
+//  Created by Neylor Bagagi on 14/07/25.
+//
+
+import Foundation
+import Combine
+import FeatureFoundation
+
+typealias ListContactsEventStream = EventStream<ListContactsEvent>
+
+enum ListContactsEvent {
+    case viewDidLoad
+}

--- a/Interview/Features/ListContacts/Sources/Core/ListContactsViewModel.swift
+++ b/Interview/Features/ListContacts/Sources/Core/ListContactsViewModel.swift
@@ -9,8 +9,6 @@ final class ListContactsViewModel {
         $displayState
     }
     
-    var viewDidLoad: (() -> Void)?
-    
     private var cancellables = Set<AnyCancellable>()
     private let dataProvider: ListContactsDataProviding
     
@@ -22,10 +20,6 @@ final class ListContactsViewModel {
     }
     
     private func binding() {
-        viewDidLoad = { [weak self] in
-            self?.dataProvider.getListContactsData()
-        }
-        
         dataProvider.dataModel
             .sink { [weak self] dataModel in
                 self?.updateDisplayState(data: dataModel)

--- a/Interview/Features/ListContacts/Sources/Glue/ListContactsBuilder.swift
+++ b/Interview/Features/ListContacts/Sources/Glue/ListContactsBuilder.swift
@@ -12,12 +12,22 @@ protocol ListContactsBuildable {
 }
  
 final public class ListContactsBuilder: ListContactsBuildable {
+    private var effectsManager: ListContactsEffectsManager?
     
     public init() {}
     
     public func build() -> UIViewController {
+        
+        let eventStream = ListContactsEventStream()
         let dataProvider = ListContactsDataProvider()
+        effectsManager = ListContactsEffectsManager(
+            eventStreamOutlet: eventStream.outlet(),
+            dataProvider: dataProvider
+        )
         let viewModel = ListContactsViewModel(dataProvider: dataProvider)
-        return ListContactsViewController(viewModel: viewModel)
+        return ListContactsViewController(
+            viewModel: viewModel,
+            eventStream: eventStream
+        )
     }
 }

--- a/Interview/Features/ListContacts/Sources/Views/ListContactsViewController.swift
+++ b/Interview/Features/ListContacts/Sources/Views/ListContactsViewController.swift
@@ -6,6 +6,7 @@ final class ListContactsViewController: UIViewController {
     
     private var viewModel: ListContactsViewModel
     private var displayState: ListContactsDisplayState
+    private var eventStream: ListContactsEventStream
     private var cancellables = Set<AnyCancellable>()
 
     lazy private var tableView: UITableView = {
@@ -22,9 +23,12 @@ final class ListContactsViewController: UIViewController {
         return tableView
     }()
     
-    public init(viewModel: ListContactsViewModel) {
+    public init(
+        viewModel: ListContactsViewModel,
+        eventStream: ListContactsEventStream) {
         self.viewModel = viewModel
         self.displayState = .emptyDisplayState()
+        self.eventStream = eventStream
         super.init(nibName: nil, bundle: nil)
         
         setupViews()
@@ -37,7 +41,7 @@ final class ListContactsViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        viewModel.viewDidLoad?()
+        eventStream.send(.viewDidLoad)
     }
     
     private func setupViews() {

--- a/Interview/Plataform/FeatureFoundation/Sources/EventStream.swift
+++ b/Interview/Plataform/FeatureFoundation/Sources/EventStream.swift
@@ -1,0 +1,35 @@
+//
+//  EventStream.swift
+//  Interview
+//
+//  Created by Neylor Bagagi on 14/07/25.
+//
+
+import Combine
+import Foundation
+
+/// An object that broadcasts elements to downstream subscribers.
+/// This is a thin wrapper of a ``PassthroughSubject`` that never completes or fails.
+public struct EventStream<EventType> {
+    /// A type-erasing AnyPublisher that allows downstream to subscribe to the events,
+    /// and hides the ``send(_:)`` functionality.
+    public typealias Outlet = AnyPublisher<EventType, Never>
+
+    private let passthroughSubject: PassthroughSubject<EventType, Never>
+
+    public init() {
+        self.passthroughSubject = PassthroughSubject<EventType, Never>()
+    }
+
+    /// Sends an event to the subscriber of this EventStream.
+    ///
+    /// - Parameter event: The event to send.
+    public func send(_ event: EventType) {
+        passthroughSubject.send(event)
+    }
+
+    /// Returns the ``Outlet`` that downstream subscribers can subscribe to.
+    public func outlet() -> Outlet {
+        passthroughSubject.eraseToAnyPublisher()
+    }
+}

--- a/Interview/Sources/AppDelegate.swift
+++ b/Interview/Sources/AppDelegate.swift
@@ -10,10 +10,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // MARK: UISceneSession Lifecycle
 
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-        
-        let config = UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
-        
-        return config
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
 
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {}


### PR DESCRIPTION
Introduced EventStream and ListContactsEvent to decouple view events from data loading logic. Added ListContactsEffectsManager to handle side effects, and updated ListContactsBuilder and ListContactsViewController to use the new event stream mechanism. Removed direct viewDidLoad callback from ListContactsViewModel for improved separation of concerns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an event-driven architecture for the contacts list, enabling more reactive updates and improved separation of concerns.
  * Added a new event stream mechanism to broadcast and handle view-related events in the contacts feature.

* **Refactor**
  * Updated the contacts list view controller and related builder to use the new event stream for handling view lifecycle events.
  * Removed the previous closure-based trigger for loading contacts, streamlining the data flow.

* **Chores**
  * Minor simplification in the app delegate for scene configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->